### PR TITLE
Fix s6-overlay-suexec error

### DIFF
--- a/acme_sh/config.json
+++ b/acme_sh/config.json
@@ -1,12 +1,13 @@
 {
   "name": "ACME.sh Certs",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "slug": "acme_sh",
   "description": "Manage certificates with ACME.sh",
   "url": "https://github.com/wernerhp/ha_addon_acme_sh",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
   "startup": "once",
   "boot": "manual",
+  "init": false,
   "map": ["ssl:rw"],
   "options": {
     "account": "str",


### PR DESCRIPTION
https://developers.home-assistant.io/blog/2022/05/12/s6-overlay-base-images/

Adds the `"init": false,` required per the above link.

Fixes #4 