### PR TITLE
Persist configuration between container runs

### DIFF
--- a/acme_sh/config.json
+++ b/acme_sh/config.json
@@ -1,6 +1,6 @@
 {
   "name": "ACME.sh Certs",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "slug": "acme_sh",
   "description": "Manage certificates with ACME.sh",
   "url": "https://github.com/wernerhp/ha_addon_acme_sh",

--- a/acme_sh/config.json
+++ b/acme_sh/config.json
@@ -1,9 +1,9 @@
 {
-  "name": "ACME.sh Certs",
-  "version": "2.1.2",
-  "slug": "acme_sh",
+  "name": "ACME.sh Certs (Persistence)",
+  "version": "2.1.3",
+  "slug": "acme_sh_persist",
   "description": "Manage certificates with ACME.sh",
-  "url": "https://github.com/wernerhp/ha_addon_acme_sh",
+  "url": "https://github.com/benze/ha_addon_acme_sh",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
   "startup": "once",
   "boot": "manual",
@@ -13,7 +13,6 @@
     "account": null,
     "server": "zerossl",
     "domains": [null],
-    "domainalias": null,
     "certfile": "fullchain.pem",
     "keyfile": "privkey.pem",
     "dns": {}
@@ -22,9 +21,10 @@
     "account": "str",
     "server": "str",
     "domains": ["str"],
-    "domainalias": "str?",
+    "domain_alias": "str?",
     "certfile": "str",
     "keyfile": "str",
+    "data_folder": "str?",
     "dns": {
       "provider": "str",
       "env": ["str"]

--- a/acme_sh/config.json
+++ b/acme_sh/config.json
@@ -10,9 +10,10 @@
   "init": false,
   "map": ["ssl:rw"],
   "options": {
-    "account": "str",
+    "account": null,
     "server": "zerossl",
     "domains": [null],
+    "domainalias": null,
     "certfile": "fullchain.pem",
     "keyfile": "privkey.pem",
     "dns": {}
@@ -21,6 +22,7 @@
     "account": "str",
     "server": "str",
     "domains": ["str"],
+    "domainalias": "str?",
     "certfile": "str",
     "keyfile": "str",
     "dns": {

--- a/acme_sh/run.sh
+++ b/acme_sh/run.sh
@@ -7,6 +7,7 @@ KEYFILE=$(bashio::config 'keyfile')
 CERTFILE=$(bashio::config 'certfile')
 DNS_PROVIDER=$(bashio::config 'dns.provider')
 DNS_ENVS=$(bashio::config 'dns.env')
+DOMAIN_ALIAS=$(bashio::config 'domainalias')
 
 for env in $DNS_ENVS; do
     export $env
@@ -20,6 +21,11 @@ done
 SERVER_ARG="zerossl"
 if [ -n "$SERVER" ]; then
     SERVER_ARG="--server $SERVER"
+fi
+
+DOMAIN_ALIAS_ARG=""
+if [ -n "$DOMAIN_ALIAS" ]; then
+    DOMAIN_ALIAS_ARG="--domain-alias $DOMAIN_ALIAS"
 fi
 
 /root/.acme.sh/acme.sh --register-account -m ${ACCOUNT} $SERVER_ARG

--- a/acme_sh/run.sh
+++ b/acme_sh/run.sh
@@ -32,7 +32,8 @@ fi
 
 /root/.acme.sh/acme.sh --issue "${DOMAIN_ARR[@]}" \
 --dns "$DNS_PROVIDER" \
-$SERVER_ARG
+$SERVER_ARG \
+$DOMAIN_ALIAS_ARG
 
 /root/.acme.sh/acme.sh --install-cert "${DOMAIN_ARR[@]}" \
 --fullchain-file "/ssl/${CERTFILE}" \

--- a/build.json
+++ b/build.json
@@ -1,9 +1,9 @@
 {
   "build_from": {
-    "aarch64": "homeassistant/aarch64-base-python:3.7-alpine3.11",
-    "amd64": "homeassistant/amd64-base-python:3.7-alpine3.11",
-    "armhf": "homeassistant/armhf-base-python:3.7-alpine3.11",
-    "armv7": "homeassistant/armv7-base-python:3.7-alpine3.11",
-    "i386": "homeassistant/i386-base-python:3.7-alpine3.11"
+    "aarch64": "homeassistant/aarch64-base-python:3.13-alpine3.20",
+    "amd64": "homeassistant/amd64-base-python:3.13-alpine3.20",
+    "armhf": "homeassistant/armhf-base-python:3.13-alpine3.20",
+    "armv7": "homeassistant/armv7-base-python:3.13-alpine3.20",
+    "i386": "homeassistant/i386-base-python:3.13-alpine3.20"
   }
 }

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
-  "name": "Home Assistant ACME.sh Certs",
-  "url": "https://github.com/albert-anderberg/ha.addon.acme_sh",
-  "maintainer": "Albert Anderberg <albert@aanet.se>"
+  "name": "Home Assistant ACME.sh Certs (Persistence)",
+  "url": "https://github.com/benze/ha.addon.acme_sh",
+  "maintainer": "Eric Benzacar <benze@users.noreply.github.com>"
 }

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
   "name": "Home Assistant ACME.sh Certs",
-  "url": "https://github.com/albert-anderberg/ha_addon_acme_sh",
+  "url": "https://github.com/albert-anderberg/ha.addon.acme_sh",
   "maintainer": "Albert Anderberg <albert@aanet.se>"
 }

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
   "name": "Home Assistant ACME.sh Certs",
-  "url": "https://github.com/wernerhp/ha_addon_acme_sh",
-  "maintainer": "Werner Pieterson <wernerhp@gmail.com>"
+  "url": "https://github.com/albert-anderberg/ha_addon_acme_sh",
+  "maintainer": "Albert Anderberg <albert@aanet.se>"
 }


### PR DESCRIPTION
Updated the run.sh script to persist acme.sh configuration data between addon runs
Addon shuts down after completion
Adds --domain-alias option (merged from https://github.com/albert-anderberg/ha.addon.acme_sh.git)